### PR TITLE
Add anomaly detection function using compute and manual variance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It simplifies common tasks by providing direct functions that operate on Arrow a
   - Filtering and comparison operations
   - Aggregation functions (sum, mean, min, max, etc.)
   - Sorting operations
+  - Anomaly detection using z-scores
 
 ## Installation
 

--- a/anomaly.go
+++ b/anomaly.go
@@ -1,0 +1,111 @@
+package archery
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+)
+
+// AnomalyResult holds mask and z-scores for anomalies.
+type AnomalyResult struct {
+	Mask   *array.Boolean
+	Zscore *array.Float64
+}
+
+// Release frees memory associated with the AnomalyResult.
+func (r *AnomalyResult) Release() {
+	if r.Mask != nil {
+		r.Mask.Release()
+	}
+	if r.Zscore != nil {
+		r.Zscore.Release()
+	}
+}
+
+// computeMeanAndVariance calculates mean and variance for a Float64 array.
+// TODO(archery): replace with compute.mean when supported
+func computeMeanAndVariance(col *array.Float64) (mean, variance float64) {
+	var sum, sumsq float64
+	var count int
+	for i := 0; i < col.Len(); i++ {
+		if col.IsNull(i) {
+			continue
+		}
+		v := col.Value(i)
+		sum += v
+		sumsq += v * v
+		count++
+	}
+	if count == 0 {
+		return 0, 0
+	}
+	mean = sum / float64(count)
+	// Population variance: sum of squared differences from mean
+	for i := 0; i < col.Len(); i++ {
+		if col.IsNull(i) {
+			continue
+		}
+		diff := col.Value(i) - mean
+		variance += diff * diff
+	}
+	variance /= float64(count)
+	return
+}
+
+// DetectAnomalies computes z-scores and a boolean mask using Arrow compute functions.
+func DetectAnomalies(ctx context.Context, col arrow.Array, threshold float64) (*AnomalyResult, error) {
+	floatCol, ok := col.(*array.Float64)
+	if !ok {
+		return nil, fmt.Errorf("input must be Float64 array, got %T", col)
+	}
+
+	mean, variance := computeMeanAndVariance(floatCol)
+
+	meanScalar := scalar.NewFloat64Scalar(mean)
+	varianceScalar := scalar.NewFloat64Scalar(variance)
+
+	stdDevRes, err := compute.CallFunction(ctx, "sqrt", nil, compute.NewDatum(varianceScalar))
+	if err != nil {
+		return nil, fmt.Errorf("sqrt computation: %w", err)
+	}
+	defer stdDevRes.Release()
+
+	stdDev := stdDevRes.(*compute.ScalarDatum).Value.(*scalar.Float64).Value
+	stdDevScalar := scalar.NewFloat64Scalar(stdDev)
+
+	diffRes, err := compute.CallFunction(ctx, "subtract", nil, compute.NewDatum(col), compute.NewDatum(meanScalar))
+	if err != nil {
+		return nil, fmt.Errorf("subtract computation: %w", err)
+	}
+	defer diffRes.Release()
+
+	zRes, err := compute.CallFunction(ctx, "divide", nil, diffRes, compute.NewDatum(stdDevScalar))
+	if err != nil {
+		return nil, fmt.Errorf("divide computation: %w", err)
+	}
+	defer zRes.Release()
+
+	absRes, err := compute.CallFunction(ctx, "abs", nil, zRes)
+	if err != nil {
+		return nil, fmt.Errorf("abs computation: %w", err)
+	}
+	defer absRes.Release()
+
+	zArr := zRes.(*compute.ArrayDatum).MakeArray().(*array.Float64)
+
+	threshScalar := scalar.NewFloat64Scalar(threshold)
+	compRes, err := compute.CallFunction(ctx, "greater_equal", nil, absRes, compute.NewDatum(threshScalar))
+	if err != nil {
+		zArr.Release()
+		return nil, fmt.Errorf("threshold comparison: %w", err)
+	}
+	defer compRes.Release()
+
+	maskArr := compRes.(*compute.ArrayDatum).MakeArray().(*array.Boolean)
+
+	return &AnomalyResult{Mask: maskArr, Zscore: zArr}, nil
+}

--- a/anomaly_test.go
+++ b/anomaly_test.go
@@ -1,0 +1,54 @@
+package archery_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/TFMV/archery"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func Example_detectAnomalies() {
+	builder := array.NewFloat64Builder(memory.DefaultAllocator)
+	defer builder.Release()
+	builder.AppendValues([]float64{1, 2, 3, 4, 5}, nil)
+	arr := builder.NewFloat64Array()
+	defer arr.Release()
+
+	ctx := context.Background()
+	res, err := archery.DetectAnomalies(ctx, arr, 1.0)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	defer res.Release()
+
+	fmt.Println("Mask:")
+	for i := 0; i < res.Mask.Len(); i++ {
+		if i > 0 {
+			fmt.Printf(" ")
+		}
+		if res.Mask.Value(i) {
+			fmt.Print("1")
+		} else {
+			fmt.Print("0")
+		}
+	}
+	fmt.Println()
+
+	fmt.Println("Z-scores:")
+	for i := 0; i < res.Zscore.Len(); i++ {
+		if i > 0 {
+			fmt.Printf(" ")
+		}
+		fmt.Printf("%.1f", res.Zscore.Value(i))
+	}
+	fmt.Println()
+
+	// Output:
+	// Mask:
+	// 1 0 0 0 1
+	// Z-scores:
+	// -1.4 -0.7 0.0 0.7 1.4
+}

--- a/docs/missing.md
+++ b/docs/missing.md
@@ -1,0 +1,12 @@
+# Missing Compute Functions
+
+The following Arrow compute functions were unavailable in github.com/apache/arrow-go/v18 v18.3.0 and are implemented manually in Archery:
+
+- `mean`
+- `variance`
+- `stddev`
+- `count`
+- `any`
+- `all`
+
+These functions should be replaced with native compute equivalents when they become available.


### PR DESCRIPTION
## Summary
- add `DetectAnomalies` with compute-based z-score calculations
- provide example test for anomaly detection
- document missing compute functions
- note anomaly detection feature in README

## Testing
- `go test -mod=vendor ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854b3f6aec4832e82fea719344e796a